### PR TITLE
Update .gitignore and add rut_format_dots.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,50 +1,7 @@
-# Learn more about Jenkins and JENKINS_HOME directory for which this file is
-# intended.
-#
-#  http://jenkins-ci.org/
-#  https://wiki.jenkins-ci.org/display/JENKINS/Administering+Jenkins
-#
-# Note: secret.key is purposefully not tracked by git. This should be backed up
-# separately because configs may contain secrets which were encrypted using the
-# secret.key.  To back up secrets use 'tar -czf /tmp/secrets.tgz secret*' and
-# save the file separate from your repository.  If you want secrets backed up
-# with configuration, then see the bottom of this file for an example.
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
-# Ignore all JENKINS_HOME except jobs directory, root xml config, and
-# .gitignore file.
-/*
-!/jobs
-!/.gitignore
-!/*.xml
-
-# Ignore all files in jobs subdirectories except for folders.
-# Note: git doesn't track folders, only file content.
-jobs/**
-!jobs/**/
-
-# Uncomment the following line to save next build numbers with config.
-
-#!jobs/**/nextBuildNumber
-
-# For performance reasons, we want to ignore builds in Jenkins jobs because it
-# contains many tiny files on large installations.  This can impact git
-# performance when running even basic commands like 'git status'.
-builds
-indexing
-
-# Exclude only config.xml files in repository subdirectories.
-!config.xml
-
-# Don't track workspaces (when users build on the master).
-jobs/**/*workspace
-
-# Security warning: If secrets are included with your configuration, then an
-# adversary will be able to decrypt all encrypted secrets within Jenkins
-# config.  Including secrets is a bad practice, but the example is included in
-# case someone still wants it for convenience.  Uncomment the following line to
-# include secrets for decryption with repository configuration in Git.
-
-#!/secret*
-
-# As a result, only Jenkins settings and job config.xml files in JENKINS_HOME
-# will be tracked by git.
+# Mac/OSX attributes/meta-data file
+.DS_Store

--- a/rut_format_dots.py
+++ b/rut_format_dots.py
@@ -1,0 +1,34 @@
+
+
+def vat_format_dot(string3):
+    """
+    This function takes a string as input and formats it according to certain conditions.
+    Input:
+        77888999-4
+    Output:
+        77.888.999-4
+    """
+    if "-" in string3:
+        parte1, parte2 = string3.split('-')
+        if parte1:
+            numero = int(parte1)
+            if numero // 1000 == 0:
+                return string3
+            lista_de_partes = []
+            while numero > 0:
+                lista_de_partes.append(str(numero % 1000))
+                numero //= 1000
+            lista_de_partes.reverse()
+            parte1_formateada = '.'.join(lista_de_partes)
+            return f"{parte1_formateada}-{parte2}"
+        else:
+            return string3
+    else:
+        return string3
+
+
+if __name__ == '__main__':
+    # Example
+    string1 = "86841749-4"
+    string2 = vat_format_dot(string1)
+    print(string2)


### PR DESCRIPTION
Updated .gitignore to include common patterns for ignoring byte-compiled, optimized, and DLL files, such as pycache/, *.py[cod], and *$py.class. Added rut_format_dots.py to the repository. This file contains a Python function named vat_format_dot that formats a Chilean VAT number (RUT) by adding dots as separators. The function takes a string input representing the VAT number and returns the formatted VAT number string.